### PR TITLE
Feat/image prompts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,9 @@ test3:
 	civitdl 123456 @test3/alphabet -s ./custom/sort.py -v
 	civitdl 78901 @test3/test3 -s test3 -v
 	civitdl 23456 @test3/tags -s tags -v
-	civitconfig default -p
+	civitconfig default --with-prompt
 	civitdl 80848 @test3/test-prompt-1 -v
-	civitconfig default -p
+	civitconfig default --no-with-prompt
 	civitdl 80848 @test3/test-prompt-2 -v
 
 test4:

--- a/Makefile
+++ b/Makefile
@@ -8,18 +8,26 @@ test2:
 	civitdl ./test/batchtest1.txt ./test/models/test2 -v
 
 test3:
-#	civitconfig sorter -a test3 ./custom/sort.py
-# civitconfig alias -a @test ./test
-# civitconfig alias -a @test3 @test/models/test3
+	# civitconfig sorter -a test3 ./custom/sort.py
+	# civitconfig alias -a @test ./test
+	# civitconfig alias -a @test3 @test/models/test3
 	civitdl 191977 @test3/default -v
 	civitdl 123456 @test3/alphabet -s ./custom/sort.py -v
 	civitdl 78901 @test3/test3 -s test3 -v
 	civitdl 23456 @test3/tags -s tags -v
+	civitconfig default -p
+	civitdl 80848 @test3/test-prompt-1 -v
+	civitconfig default -p
+	civitdl 80848 @test3/test-prompt-2 -v
+
+test4:
+	civitdl 80848 ./test/models/test4/with-prompt -v --with-prompt
+	civitdl 80848 ./test/models/test4/without-prompt -v --no-with-prompt
 
 errortest1:
-	civitdl batchfile ./test/errortest1.txt ./test/models/test2 -d
+	civitdl batchfile ./test/errortest1.txt ./test/models/test2 -d -v
 
-test: install test1 test2
+test: install test1 test2 test4
 
 
 clean:

--- a/README.md
+++ b/README.md
@@ -136,13 +136,17 @@ civitdl model_id rootpath
 #### Main Program Options - civitdl
 - Run `civitdl --help` to check what options are available!
 
-Three options are available
+Four options are available
 - `-i <number>` or `--max-images <number>`
   - Specifies the max images to download for each model.
-  - Example: `civitdl 123456 ./loras -i 20`
+  - Example: `civitdl 80848 ./loras -i 20`
+- `p` or `--with-prompt`
+  - Running with the option will download an image's JSON prompt/metadata alongside the image.
+  - Example: `civitdl 80848 ./loras --with-prompt`
+  - Use `--no-with-prompt` to disable downloading JSON prompt/metadata.
 - `-s <sorter-name / path>` or `--sorter <sorter-name / path>`
   - Specifies which sorter to use. The default uses the basic sorter.
-  - See [sorter doc](./doc/sorter.md) for more infor.
+  - See [sorter doc](./doc/sorter.md) for more info.
   - Example: `civitdl 123456 ./loras -s tags`
 - `-k` or `--api-key`
   - Running with this option will prompt the user to type in their API key.

--- a/custom/sort.py
+++ b/custom/sort.py
@@ -22,8 +22,9 @@ def sort_model(model_dict: Dict, version_dict: Dict, filename: str, root_path: s
     extra_data_dir = os.path.join(
         parent_dir, f'extra_data-vid_{version_dict["id"]}')
     paths = [
-        parent_dir,      # model path
-        extra_data_dir,  # metadata path
-        extra_data_dir   # image path
+        parent_dir,      # model dir path
+        extra_data_dir,  # metadata dir path
+        extra_data_dir,  # image dir path
+        extra_data_dir   # prompt dir path
     ]
     return paths

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -20,6 +20,7 @@
   - [Table Of Contents](#table-of-contents)
   - [Defaults](#defaults)
     - [Set max image](#set-max-image)
+    - [Set with prompt](#set-with-prompt)
     - [Set sorter](#set-sorter)
       - [What is a sorter?](#what-is-a-sorter)
     - [Set api key](#set-api-key)
@@ -51,6 +52,18 @@ To set the default max images to N (N >= 0):
 - Longhand: `civitconfig default --max-images N`
 
 Set the default max image to a number you are comfortable with when you run `civitdl`
+
+<br/>
+
+### Set with prompt
+- This sets the default attribute `with-prompt` on whether to download images when `civitdl` is run without the option `-p` or `--with-prompt` or `--no-with-prompt`
+
+To set the default attribute for enabling `with-prompt`:
+- Shorthand: `civitconfig default -p`
+- Longhand: `civitconfig default --with-prompt`
+
+To set the default attribute for disabling `with-prompt`:
+- Longhand: `civitconfig default --no-with-prompt`
 
 <br/>
 

--- a/doc/sorter.md
+++ b/doc/sorter.md
@@ -55,8 +55,11 @@ stable-diffusion-webui/
       | extra_data-vid_75/
         | model_dict-mid_66-vid_75.json
         | 517.jpeg
+        | 517-prompt.json
         | 525.jpeg
+        | 525-prompt.json
         | 526.jpeg
+        | 526-prompt.json
 ```
 
 `basic` is the **default** sorter, and it is possible to change the parent directory name from `anythingv3_fp16` to any other name in a **custom sorter**.
@@ -90,8 +93,11 @@ stable-diffusion-webui/
             | extra_data-vid_85767/
               | model_dict-mid_80848-vid_85767.json
               | 972495.jpeg
+              | 972495-prompt.json
               | 972496.jpeg
+              | 972496-prompt.json
               | 972497.jpeg
+              | 972497-prompt.json
 ```
 
 
@@ -135,10 +141,12 @@ def sort_model(model_dict: Dict, version_dict: Dict, filename: str, root_path: s
     model_dir_path = '/path/to/model/parent/dir'
     metadata_dir_path = '/path/to/metadata/parent/dir'
     image_dir_path = '/path/to/image/parent/dir'
+    prompt_dir_path = '/path/to/prompt/parent/dir'
     return [
-      model_dir_path, # Parent dir of where the downloaded model should be in
-      metadata_dir_path, # Parent dir of where the JSON metadata should be in
-      image_dir_path # Parent dir of where the images should be in
+      model_dir_path,     # Parent dir of where the downloaded model should be in
+      metadata_dir_path,  # Parent dir of where the JSON metadata should be in
+      image_dir_path      # Parent dir of where the images should be in
+      prompt_dir_path     # Parent dir of where the images' prompt should be in
     ]
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "civitdl"
-version = "2.0.0-dev6"
+version = "2.0.0-dev7"
 authors = [ 
    { name = "Owen Truong" } 
 ]

--- a/src/civitconfig/__main__.py
+++ b/src/civitconfig/__main__.py
@@ -18,13 +18,15 @@ def main():
         run_in_dev(print, args)
 
         if subcommand == 'default':
-            if 'max_images' in args or 'sorter' in args or 'api_key' in args:
+            if 'max_images' in args or 'with_prompt' or 'sorter' in args or 'api_key' in args:
+                print(args['with_prompt'])
                 config_manager.setDefault(
-                    max_images=args['max_images'], sorter=args['sorter'], api_key=args['api_key'])
-            (max_images, sorter, _) = config_manager.getDefaultAsList()
+                    max_images=args['max_images'], with_prompt=args['with_prompt'], sorter=args['sorter'], api_key=args['api_key'])
+            (max_images, with_prompt, sorter, _) = config_manager.getDefaultAsList()
             print(add_colors('Default:', 'green'))
             print(add_colors(f'     Max Images:         {max_images}', 'blue'))
-            print(add_colors(f'     Sorter:             {sorter}', 'green'))
+            print(add_colors(f'     With Prompt:        {with_prompt}', 'green'))
+            print(add_colors(f'     Sorter:             {sorter}', 'blue'))
         elif subcommand == 'sorter':
             if args['add'] != None:
                 add_name, add_path = args['add']

--- a/src/civitconfig/args/argparser.py
+++ b/src/civitconfig/args/argparser.py
@@ -34,6 +34,7 @@ default_parser = subparsers.add_parser(
     'default', help='Set a default value for one of the options below.\nIf no options are provided, default will print the current default.')
 default_parser.add_argument('-i', '--max-images', metavar='INT', type=int,
                             help='Set the default max number of images to download per model.')
+default_parser.add_argument('-p', '--with-prompt', action=argparse.BooleanOptionalAction, help='Toggles default behavior on whether to download prompt alongside images.')
 default_parser.add_argument('-s', '--sorter', metavar='NAME', type=str,
                             help='Set the default sorter given name of sorter (filepath not accepted).')
 default_parser.add_argument('-k', '--api-key', action=PwdAction, type=str, nargs=0,

--- a/src/civitconfig/data/config/config.py
+++ b/src/civitconfig/data/config/config.py
@@ -12,6 +12,7 @@ DEFAULT_CONFIG = {
     "version": "1",
     "default": {
         "max_images": 3,
+        "with_prompt": True,
         "sorter": "basic",
         "api_key": ""
     },

--- a/src/civitconfig/data/config/defaultconfig.py
+++ b/src/civitconfig/data/config/defaultconfig.py
@@ -10,19 +10,29 @@ class DefaultConfig(Config):
     def _setMaxImages(self, config, max_images):
         config['default']['max_images'] = max_images
 
+    def _setWithPrompt(self, config):
+        if config['default']['with_prompt'] == True:
+            config['default']['with_prompt'] = False
+        else:
+            config['default']['with_prompt'] = True
+
     def _setSorter(self, config, sorter):
         config['default']['sorter'] = sorter
 
     def _setApiKey(self, config, key):
         config['default']['api_key'] = key
 
-    def setDefault(self, max_images=None, sorter=None, api_key=None):
+    def setDefault(self, max_images=None, with_prompt=None, sorter=None, api_key=None):
         config = self._getConfig()
         if max_images:
             if type(max_images) != int or max_images < 0:
                 raise InputException(
                     f'max_images argument is not type int or max_images is below 0. The following was provided: {max_images}')
             self._setMaxImages(config, max_images)
+        if with_prompt:
+            if type(with_prompt) != bool:
+                raise InputException(f'with_prompt argument is not of type bool.')
+            self._setWithPrompt(config)
         if sorter:
             if len([s for s in self.getSortersList() if s[0] == sorter]) != 1:
                 raise InputException(f'Sorter "{sorter}" does not exist')

--- a/src/civitconfig/data/config/defaultconfig.py
+++ b/src/civitconfig/data/config/defaultconfig.py
@@ -10,11 +10,11 @@ class DefaultConfig(Config):
     def _setMaxImages(self, config, max_images):
         config['default']['max_images'] = max_images
 
-    def _setWithPrompt(self, config):
-        if config['default']['with_prompt'] == True:
-            config['default']['with_prompt'] = False
-        else:
+    def _setWithPrompt(self, config, with_prompt):
+        if with_prompt == True:
             config['default']['with_prompt'] = True
+        else:
+            config['default']['with_prompt'] = False
 
     def _setSorter(self, config, sorter):
         config['default']['sorter'] = sorter
@@ -24,19 +24,19 @@ class DefaultConfig(Config):
 
     def setDefault(self, max_images=None, with_prompt=None, sorter=None, api_key=None):
         config = self._getConfig()
-        if max_images:
+        if max_images != None:
             if type(max_images) != int or max_images < 0:
                 raise InputException(
                     f'max_images argument is not type int or max_images is below 0. The following was provided: {max_images}')
             self._setMaxImages(config, max_images)
-        if with_prompt:
+        if with_prompt != None:
             if type(with_prompt) != bool:
                 raise InputException(f'with_prompt argument is not of type bool.')
-            self._setWithPrompt(config)
-        if sorter:
+            self._setWithPrompt(config, with_prompt)
+        if sorter != None:
             if len([s for s in self.getSortersList() if s[0] == sorter]) != 1:
                 raise InputException(f'Sorter "{sorter}" does not exist')
             self._setSorter(config, sorter)
-        if api_key:
+        if api_key != None:
             self._setApiKey(config, api_key)
         self._saveConfig(config)

--- a/src/civitconfig/data/configmanager.py
+++ b/src/civitconfig/data/configmanager.py
@@ -69,8 +69,8 @@ class ConfigManager(Config):
 
         self._saveConfig(DEFAULT_CONFIG)
 
-    def setDefault(self, max_images, sorter, api_key):
-        self._defaultConfig.setDefault(max_images, sorter, api_key)
+    def setDefault(self, max_images, with_prompt, sorter, api_key):
+        self._defaultConfig.setDefault(max_images, with_prompt, sorter, api_key)
 
     def addAlias(self, alias_name: str, path: str):
         self._aliasConfig.addAlias(alias_name, path)

--- a/src/civitdl/__main__.py
+++ b/src/civitdl/__main__.py
@@ -9,14 +9,15 @@ from .args.argparser import get_args
 
 def main():
     try:
-        ids, rootdir, sorter, max_imgs, api_key = itemgetter(
-            'ids', 'rootdir', 'sorter', 'max_imgs', 'api_key')(get_args())
+        ids, rootdir, sorter, max_imgs, with_prompt, api_key = itemgetter(
+            'ids', 'rootdir', 'sorter', 'max_imgs', 'with_prompt', 'api_key')(get_args())
 
         batch_download(
             ids,
             rootdir=rootdir,
             sorter=sorter,
             max_imgs=max_imgs,
+            with_prompt=with_prompt,
             api_key=api_key)
 
     except Exception as e:

--- a/src/civitdl/args/argparser.py
+++ b/src/civitdl/args/argparser.py
@@ -135,6 +135,8 @@ parser.add_argument('-s', '--sorter', type=str,
 parser.add_argument('-i', '--max-images', metavar='INT', type=int,
                     help='Specify max images to download for each model.')
 
+parser.add_argument('-p', '--with-prompt', action=argparse.BooleanOptionalAction, help='Download images with prompt.')
+
 parser.add_argument('-k', '--api-key', action=PwdAction, type=str, nargs=0,
                     help='Prompt user for api key to download models that require users to log in.')
 
@@ -145,7 +147,7 @@ parser.add_argument(
 def get_args():
     parser_result = parser.parse_args()
     config_manager = ConfigManager()
-    d_max_imgs, d_sorter_name, d_api_key = config_manager.getDefaultAsList()
+    d_max_imgs, d_with_prompt, d_sorter_name, d_api_key = config_manager.getDefaultAsList()
     sorters = config_manager.getSortersList()
     aliases = config_manager.getAliasesList()
 
@@ -157,5 +159,6 @@ def get_args():
         "rootdir": parse_rootdir(aliases, parser_result.rootdir),
         "sorter": parse_sorter(sorters, parser_result.sorter or d_sorter_name),
         "max_imgs": parser_result.max_images or d_max_imgs,
+        "with_prompt": parser_result.with_prompt or d_with_prompt,
         "api_key": parser_result.api_key or d_api_key
     }

--- a/src/civitdl/batch/_get_model.py
+++ b/src/civitdl/batch/_get_model.py
@@ -85,16 +85,18 @@ class Metadata:
                 f'\nOriginal Error:\n       {e}')
 
 
-def _download_image(dirpath: str, images: List[Dict], nsfw: bool, max_img_count):
+def _download_images(dirpath: str, images: List[Dict], nsfw: bool, max_img_count: int):
     def make_req(url): return requests.get(url, stream=True)
 
     image_urls = []
+    interested_images = []
     for dict in images:
         if len(image_urls) == max_img_count:
             break
         if not nsfw and dict['nsfw'] != 'None':
             continue
         else:
+            interested_images.append(dict)
             image_urls.append(dict['url'])
 
     os.makedirs(dirpath, exist_ok=True)
@@ -117,6 +119,12 @@ def _download_image(dirpath: str, images: List[Dict], nsfw: bool, max_img_count)
     else:
         write_to_files(dirpath, base_name_list, image_data_list, mode='wb',
                        use_pb=True, total=len(base_name_list), desc='Images')
+        
+    return (base_name_list, interested_images)
+
+def _download_prompts(dirpath: str, base_name_list: List[str], images: List[Dict]):
+    if (len(images) != 0):
+        write_to_files(dirpath, base_name_list, [dumps(image, indent=2, ensure_ascii=False) for image in images])
 
 
 def _download_metadata(dirpath: str, metadata: Metadata):
@@ -171,7 +179,7 @@ def _get_filename_and_model_res(input_str: str, metadata: Metadata, api_key: Uni
     return (res, filename)
 
 
-def download_model(id: Id, create_dir_path: Callable[[Dict, Dict, str, str], str], dst_root_path: str, max_img_count: int, api_key: Union[str, None] = None):
+def download_model(id: Id, create_dir_path: Callable[[Dict, Dict, str, str], str], dst_root_path: str, max_img_count: int, with_prompt: bool, api_key: Union[str, None] = None):
     """
         Downloads the model's safetensors and json metadata files.
         create_dir_path is a callback function that takes in the following: metadata dict, specific model's data as dict, filename, and root path.
@@ -199,11 +207,11 @@ def download_model(id: Id, create_dir_path: Callable[[Dict, Dict, str, str], str
     paths = create_dir_path(
         metadata.model_dict, metadata.version_dict, filename_without_ext, dst_root_path)
 
-    if len(paths) != 3:
+    if len(paths) != 4:
         raise InputException(
             'Sorter function provided returned invalid # of paths.')
 
-    model_dir_path, metadata_dir_path, image_dir_path = paths
+    model_dir_path, metadata_dir_path, image_dir_path, prompt_dir_path = paths
 
     # Write model to the directory #
 
@@ -212,8 +220,12 @@ def download_model(id: Id, create_dir_path: Callable[[Dict, Dict, str, str], str
     _download_metadata(metadata_dir_path, metadata)
 
     # Download images
-    _download_image(
+    image_base_names, remaining_images = _download_images(
         image_dir_path, metadata.version_dict['images'], metadata.nsfw, max_img_count)
+    
+    # Download prompts
+    if with_prompt:
+        _download_prompts(prompt_dir_path, [f'{os.path.splitext(base_name)[0]}-prompt.json' for base_name in image_base_names], remaining_images)
 
     # Download file
     os.makedirs(model_dir_path, exist_ok=True)

--- a/src/civitdl/batch/batch_download.py
+++ b/src/civitdl/batch/batch_download.py
@@ -15,7 +15,7 @@ def choose_sorter(sorter_str: str):
         return import_sort_model(sorter_str)
 
 
-def batch_download(ids, rootdir, sorter, max_imgs, api_key=None):
+def batch_download(ids, rootdir, sorter, max_imgs, with_prompt, api_key=None):
     """Batch downloads model from CivitAI one by one."""
 
     for id in ids:
@@ -25,6 +25,7 @@ def batch_download(ids, rootdir, sorter, max_imgs, api_key=None):
                 create_dir_path=choose_sorter(sorter),
                 dst_root_path=rootdir,
                 max_img_count=max_imgs,
+                with_prompt=with_prompt,
                 api_key=api_key)
             run_in_dev(print, 'Pausing for 3 seconds...')
             time.sleep(3)

--- a/src/helpers/sorter/basic.py
+++ b/src/helpers/sorter/basic.py
@@ -8,8 +8,9 @@ def sort_model(model_dict: Dict, version_dict: Dict, filename: str, root_path: s
     extra_data_dir = os.path.join(
         parent_dir, f'extra_data-vid_{version_dict["id"]}')
     paths = [
-        parent_dir,      # model path
-        extra_data_dir,  # metadata path
-        extra_data_dir   # image path
+        parent_dir,      # model dir path
+        extra_data_dir,  # metadata dir path
+        extra_data_dir,  # image dir path
+        extra_data_dir   # prompt dir path
     ]
     return paths

--- a/src/helpers/sorter/tags.py
+++ b/src/helpers/sorter/tags.py
@@ -22,9 +22,10 @@ def sort_model(model_dict: Dict, version_dict: Dict, filename: str, root_path: s
     extra_data_dir = os.path.join(
         parent_dir, f'extra_data-vid_{version_dict["id"]}')
     paths = [
-        parent_dir,      # model path
-        extra_data_dir,  # metadata path
-        extra_data_dir   # image path
+        parent_dir,      # model dir path
+        extra_data_dir,  # metadata dir path
+        extra_data_dir,  # image dir path
+        extra_data_dir   # prompt dir path
     ]
 
     return paths


### PR DESCRIPTION
**Summary**
- Modified code in civitconfig and civitdl to accept with-prompt options for downloading image's JSON metadata/prompt.
  - Keep in mind that the metadata/prompt already exist in metadata.json that is downloaded alongside each model.
- Modified readme to reflect the changes above.

**Related Issue**
Closes #36