### PR TITLE
Feat/request session

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "civitdl"
-version = "2.0.0-dev10"
+version = "2.0.0-dev11"
 authors = [ 
    { name = "Owen Truong" } 
 ]

--- a/src/civitdl/__main__.py
+++ b/src/civitdl/__main__.py
@@ -3,7 +3,7 @@ import traceback
 from operator import itemgetter
 
 from helpers.utils import run_in_dev, print_exc
-from .batch.batch_download import batch_download
+from .batch.batch_download import batch_download, Config
 from .args.argparser import get_args
 
 
@@ -15,10 +15,13 @@ def main():
         batch_download(
             ids,
             rootdir=rootdir,
-            sorter=sorter,
-            max_imgs=max_imgs,
-            with_prompt=with_prompt,
-            api_key=api_key)
+            config=Config(
+                sorter=sorter,
+                max_imgs=max_imgs,
+                with_prompt=with_prompt,
+                api_key=api_key
+            )
+        )
 
     except Exception as e:
         print('---------')

--- a/src/civitdl/batch/batch_download.py
+++ b/src/civitdl/batch/batch_download.py
@@ -2,29 +2,30 @@ import importlib.util
 import itertools
 import time
 import traceback
-from typing import Dict
+from typing import Dict, Union
+from dataclasses import dataclass
 
 from ._get_model import download_model
 
 from helpers.styler import Styler
-from helpers.utils import get_env, print_exc, print_in_dev, run_in_dev, import_sort_model
+from helpers.utils import Config, get_env, print_exc, print_in_dev, run_in_dev, import_sort_model
 from helpers.sorter import basic, tags
 
 
-def choose_sorter(sorter_str: str):
+def _choose_sorter(sorter_str: str):
     if sorter_str == 'basic' or sorter_str == 'tags':
         return tags.sort_model if sorter_str == 'tags' else basic.sort_model
     else:
         return import_sort_model(sorter_str)
 
 
-def pause(sec):
+def _pause(sec):
     print_in_dev('Pausing for 3 seconds...')
     time.sleep(sec)
     print_in_dev('Waking up!')
 
 
-def batch_download(ids, rootdir, sorter, max_imgs, with_prompt, retry_count=3, pause_time=3, api_key=None):
+def batch_download(ids, rootdir, config: Config):
     """Batch downloads model from CivitAI one by one."""
 
     for id in ids:
@@ -33,24 +34,23 @@ def batch_download(ids, rootdir, sorter, max_imgs, with_prompt, retry_count=3, p
             try:
                 download_model(
                     id=id,
-                    create_dir_path=choose_sorter(sorter),
                     dst_root_path=rootdir,
-                    max_img_count=max_imgs,
-                    with_prompt=with_prompt,
-                    api_key=api_key)
-                pause(pause_time)
+                    create_dir_path=_choose_sorter(config.sorter),
+                    config=config
+                )
+                _pause(config.pause_time)
                 break
             except Exception as e:
                 print('---------')
                 run_in_dev(traceback.print_exc)
                 print_exc(e, '\n')
                 print('---------')
-                pause(pause_time)
-                if iter < retry_count:
+                _pause(config.pause_time)
+                if iter < config.retry_count:
                     print(Styler.stylize(
                         'Retrying to download the current model...', color='info'))
                     iter += 1
                 else:
                     print(Styler.stylize(
-                        f'Max retry of {retry_count} reached. Skipping the current model...', color='info'))
+                        f'Max retry of {config.retry_count} reached. Skipping the current model...', color='info'))
                     break

--- a/src/helpers/utils.py
+++ b/src/helpers/utils.py
@@ -6,6 +6,7 @@ import sys
 from typing import Callable, Dict, Iterable, Union
 import importlib.util
 import concurrent.futures
+import requests
 from tqdm import tqdm
 
 from helpers.styler import Styler
@@ -119,3 +120,6 @@ class Config:
     max_imgs: int = 3
     with_prompt: bool = True
     api_key: Union[str, None] = None
+
+    def __post_init__(self):
+        self.session = requests.Session()

--- a/src/helpers/utils.py
+++ b/src/helpers/utils.py
@@ -90,7 +90,7 @@ def print_exc(exc: Exception, *args, **kwargs):
     if isinstance(exc, CustomException):
         print(exc, file=sys.stderr, *args, **kwargs)
     else:
-        print(Styler.stylize(str(exc), *args, color='exception'),
+        print(Styler.stylize(str(exc), color='exception'), *args,
               file=sys.stderr, **kwargs)
 
 

--- a/src/helpers/utils.py
+++ b/src/helpers/utils.py
@@ -1,12 +1,11 @@
+from dataclasses import dataclass
 from datetime import datetime
 import json
 import os
 import sys
-from typing import Callable, Dict, Iterable
+from typing import Callable, Dict, Iterable, Union
 import importlib.util
 import concurrent.futures
-
-
 from tqdm import tqdm
 
 from helpers.styler import Styler
@@ -30,10 +29,10 @@ def set_env(env: str):
 # TODO: what if a specific image have a hard time with getting a response?
 
 
-def concurrent_request(req_fn, urls):
+def concurrent_request(req_fn, urls, max_workers=16):
     res_list = None
 
-    with concurrent.futures.ThreadPoolExecutor() as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = [executor.submit(req_fn, url) for url in urls]
         res_list = [future.result() for future in futures]
 
@@ -109,3 +108,14 @@ def getDate():
 def createDirsIfNotExist(dirpaths):
     for dirpath in dirpaths:
         os.makedirs(dirpath, exist_ok=True)
+
+
+@dataclass
+class Config:
+    sorter: str = 'basic'
+    retry_count: int = 3
+    pause_time: int = 3
+
+    max_imgs: int = 3
+    with_prompt: bool = True
+    api_key: Union[str, None] = None


### PR DESCRIPTION
Summary
- Fixed bugs with print_exc.
- Added max_workers to concurrent_request.
- Refactored how images are handled (now Metadata class handle all of the details related to which images to download).
- Now using request.Session.

Related Issues:
Closes #54 

Comments:

According to the two link below, using request.Session with threads are fine as long as there is only a low number of hosts and we are not modifying anything related to cookies. For this repo, we don't use cookies and the only host we make requests to is CivitAI.

https://stackoverflow.com/questions/18188044/is-the-session-object-from-pythons-requests-library-thread-safe
https://github.com/ross/requests-futures/issues/47