### PR TITLE
fix issue when download_time is 0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "civitdl"
-version = "2.0.1"
+version = "2.0.2"
 authors = [ 
    { name = "Owen Truong" } 
 ]

--- a/src/helpers/utils.py
+++ b/src/helpers/utils.py
@@ -104,7 +104,8 @@ def write_contents(file: IO, content_chunks: Iterable, limit_rate: Union[int, No
         bytes_downloaded = len(content)
 
         download_time = time.perf_counter() - last_chunk_time
-        speed = bytes_downloaded / download_time
+        speed = bytes_downloaded / \
+            download_time if download_time != 0 else float('inf')
         if limit_rate is not None and limit_rate is not 0 and speed > limit_rate:
             time_to_sleep = (bytes_downloaded / limit_rate) - download_time
             if time_to_sleep > 0:


### PR DESCRIPTION
**Summary**
- Changed math for calculating time to sleep after each chunk of model is downloaded.


**Related Issues?**
Link all related issue. Even the ones that are not being closed.
#68 

**Comments**
Current bug with `download_time` is that when your internet and computer is too fast, `download_time` might be near 0, and that causes integer division by 0 error. To solve this, when `download_time` = 0, the calculation for `speed` of model download will be replaced with infinity.
