### PR TITLE
Fixed critical string formatting (autopep8) issue on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ install: uninstall
 	pip3 install .
 
 install2: uninstall
+	rm -rf dist build
 	python3 -m build
 	pip3 install -r ./requirements.txt
 	pip3 install --upgrade dist/*.whl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "civitdl"
-version = "2.0.8"
+version = "2.0.9"
 authors = [ 
    { name = "Owen Truong" } 
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "civitdl"
-version = "2.0.7"
+version = "2.0.8"
 authors = [ 
    { name = "Owen Truong" } 
 ]

--- a/src/civitdl/batch/_get_model.py
+++ b/src/civitdl/batch/_get_model.py
@@ -149,8 +149,7 @@ def _download_prompts(dirpath: str, basenames: List[str], image_dicts: List[Dict
 
 def _download_metadata(dirpath: str, metadata: Metadata):
 
-    model_dict_filename = f'model_dict-mid_{
-        metadata.model_id}-vid_{metadata.version_id}.json'
+    model_dict_filename = f'model_dict-mid_{metadata.model_id}-vid_{metadata.version_id}.json'  # nopep8 # Linux issue
     model_dict_path = os.path.join(
         dirpath, model_dict_filename)
     os.makedirs(dirpath, exist_ok=True)
@@ -271,8 +270,7 @@ def download_model(id: Id, dst_root_path: str, batchOptions: BatchOptions):
 
     # Download model & hashes
     os.makedirs(sorter_data.model_dir_path, exist_ok=True)
-    model_filename_no_ext = f'{
-        filename_no_ext}-mid_{metadata.model_id}-vid_{metadata.version_id}'
+    model_filename_no_ext = f'{filename_no_ext}-mid_{metadata.model_id}-vid_{metadata.version_id}'  # nopep8 # Linux issue
 
     _download_hashes(sorter_data.model_dir_path,
                      model_filename_no_ext,

--- a/src/civitdl/batch/_get_model.py
+++ b/src/civitdl/batch/_get_model.py
@@ -101,8 +101,7 @@ class Metadata:
         return self.__get_metadata(metadata_url)
 
     def __get_version_metadata(self):
-        metadata_url = f'https://civitai.com/api/v1/model-versions/{
-            self.version_id}'
+        metadata_url = f'https://civitai.com/api/v1/model-versions/{self.version_id}'  # nopep8 # Linux issue
         return self.__get_metadata(metadata_url)
 
     def __get_metadata(self, url: str):


### PR DESCRIPTION
**Summary**
- Disable string formatting for strings that take up 2 lines.
