### PR TITLE
Bug/401 issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "civitdl"
-version = "2.0.11"
+version = "2.0.12"
 authors = [ 
    { name = "Owen Truong" } 
 ]

--- a/src/civitdl/batch/_get_model.py
+++ b/src/civitdl/batch/_get_model.py
@@ -180,7 +180,7 @@ def _get_filename_and_model_res(input_str: str, metadata: Metadata, batchOptions
     print_verbose(f'Model Download API URL: {metadata.model_download_url}')
     res = batchOptions.session.get(metadata.model_download_url, stream=True)
 
-    if 'reason=download-auth' in res.url:
+    if 'reason=download-auth' in res.url or res.status_code == 401:
         api_key_needed = True
         if batchOptions.api_key:
             headers = {


### PR DESCRIPTION
**Summary**
- Added conditional statement for status 401 returned to Civitai.


**Related Issues?**
Link all related issue. Even the ones that are not being closed.
Closes #90 

**Comments**
 Currently, program only use api key when status=401 or the url is related to unauth, but recently CivitAI has changed their API so that all models require an api key. It may be of interest to remove the conditional statement and for the program to always require an api key instead.
