### PR TITLE
feat: program can now scan a directory to add model file to cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Uses CLI to batch download Stable Diffusion models, metadata (including descript
 - [API Key Page](/doc/api_key.md)
 - [Civitconfig / Configuration Page](/doc/civitconfig.md)
 - [Civitdl Page](/doc/civitdl.md)
+- [Civitmisc Page](/doc/civitmisc.md)
 - [Sorter Page](/doc/sorter.md)
 
 <br/>

--- a/doc/alias.md
+++ b/doc/alias.md
@@ -10,6 +10,7 @@
 - [API Key Page](/doc/api_key.md)
 - [Civitconfig / Configuration Page](/doc/civitconfig.md)
 - [Civitdl Page](/doc/civitdl.md)
+- [Civitmisc Page](/doc/civitmisc.md)
 - [Sorter Page](/doc/sorter.md)
 
 <br/>

--- a/doc/api_key.md
+++ b/doc/api_key.md
@@ -9,6 +9,7 @@
 - [API Key Page](/doc/api_key.md)
 - [Civitconfig / Configuration Page](/doc/civitconfig.md)
 - [Civitdl Page](/doc/civitdl.md)
+- [Civitmisc Page](/doc/civitmisc.md)
 - [Sorter Page](/doc/sorter.md)
 
 <br/>

--- a/doc/civitconfig.md
+++ b/doc/civitconfig.md
@@ -10,6 +10,7 @@
 - [API Key Page](/doc/api_key.md)
 - [Civitconfig / Configuration Page](/doc/civitconfig.md)
 - [Civitdl Page](/doc/civitdl.md)
+- [Civitmisc Page](/doc/civitmisc.md)
 - [Sorter Page](/doc/sorter.md)
 
 <br/>
@@ -175,5 +176,3 @@ To set the default attribute for disabling `with-prompt`:
 - Shorthand: `civitconfig settings -d /path/to/zipped-config.zip`
 - Longhand: `civitconfig settings --download /path/to/zipped-config.zip`
 - Run to download your configuration as a zip file.
-
-

--- a/doc/civitdl.md
+++ b/doc/civitdl.md
@@ -9,6 +9,7 @@
 - [API Key Page](/doc/api_key.md)
 - [Civitconfig / Configuration Page](/doc/civitconfig.md)
 - [Civitdl Page](/doc/civitdl.md)
+- [Civitmisc Page](/doc/civitmisc.md)
 - [Sorter Page](/doc/sorter.md)
 
 <br/>

--- a/doc/civitmisc.md
+++ b/doc/civitmisc.md
@@ -1,0 +1,39 @@
+# Civitmisc
+- In this page, we will go over various tasks that do not directly relate to configuration and downloading model from the API.
+- Run `civitmisc --help` when you need help on some options!
+
+<br/>
+
+## Navigate
+- [README Page](/README.md)
+- [Alias Page](/doc/alias.md)
+- [API Key Page](/doc/api_key.md)
+- [Civitconfig / Configuration Page](/doc/civitconfig.md)
+- [Civitdl Page](/doc/civitdl.md)
+- [Civitmisc Page](/doc/civitmisc.md)
+- [Sorter Page](/doc/sorter.md)
+
+<br/>
+
+## Table Of Contents
+- [Civitmisc](#civitmisc)
+  - [Navigate](#navigate)
+  - [Table Of Contents](#table-of-contents)
+  - [Cache](#cache)
+    - [Scan Model](#scan-model)
+
+<br/>
+
+## Cache
+Operations relating to the cache. The cache currently contains the file path and hash of each model that have been downloaded. Note that only one file path may be stored, so if you tried to download the same model multiple time in different directories, the file path saved will be the last time you downloaded the same model.
+- If a file path is stored in cache, next time `civitdl` is requested to download the same model, it will automatically copy the file from the file path stored in the cache.
+- See `civitconfig cache --help`
+
+<br/>
+
+### Scan Model
+- This scans a directory recursively to find model files with matching file names. The syntax is `mid_x-vid_y` in the file name where `mid` is model id, `vid` is version id, and `x` & `y` are substitued with valid model and version ids. Please try not to change the file name so that `-s` or `--scan-model` works properly.
+- This is also useful if you want to check if any of your downloaded models have been corrupted as SHA256 is used to check the integrity of every model file `scan-model` finds.
+- Shorthand: `civitmisc cache -s /path/to/directory`
+- Longhand: `civitmisc cache -s /path/to/directory`
+

--- a/doc/sorter.md
+++ b/doc/sorter.md
@@ -9,6 +9,7 @@
 - [API Key Page](/doc/api_key.md)
 - [Civitconfig / Configuration Page](/doc/civitconfig.md)
 - [Civitdl Page](/doc/civitdl.md)
+- [Civitmisc Page](/doc/civitmisc.md)
 - [Sorter Page](/doc/sorter.md)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,4 @@ Repository = "https://github.com/OwenTruong/civitdl"
 [project.scripts]
 civitdl = "civitdl.__main__:main"
 civitconfig = "civitconfig.__main__:main"
+civitmisc = "civitmisc.__main__:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "civitdl"
-version = "2.1.0.dev2"
+version = "2.1.0.dev3"
 authors = [ 
    { name = "Owen Truong" } 
 ]

--- a/src/civitconfig/data/configmanager.py
+++ b/src/civitconfig/data/configmanager.py
@@ -102,3 +102,5 @@ class ConfigManager(Config):
             f'Downloading zipped config to {dst_path}.zip', color='main'))
         shutil.make_archive(dst_path, 'zip',
                             self._config_dir_path)
+
+    # def scanPath(self, dir_path):

--- a/src/civitdl/batch/_model.py
+++ b/src/civitdl/batch/_model.py
@@ -12,7 +12,7 @@ from helpers.core.iohelper import IOHelper
 
 from helpers.sourcemanager import Id
 from helpers.options import BatchOptions
-from helpers.cachemanager import CacheManager
+from helpers.cache import Cache
 
 from ._metadata import Metadata
 
@@ -72,9 +72,9 @@ class Model:
         sha256_hash = version_hashes.get('SHA256', None)
         try:
             if self.__batchOptions.cache_mode == '1':
-                cache_manager = CacheManager(
+                cache = Cache(
                     version_id)
-                cached_filepath = cache_manager.get_local_model_path()
+                cached_filepath = cache.get_local_model_path()
         except:
             sprint(Styler.stylize('Unable to access cache.', color='warning'))
 
@@ -87,8 +87,8 @@ class Model:
                                    use_pb=True, total=float(model_res.headers.get('content-length', 0)), desc='Model')
 
         def cache_model_info():
-            if self.__batchOptions.cache_mode == '1' and cache_manager:
-                cache_manager.set_local_model_cache(
+            if self.__batchOptions.cache_mode == '1' and cache:
+                cache.set_local_model_cache(
                     filepath, version_hashes)
 
         if (self.__batchOptions.strict_mode == '1' and not sha256_hash):

--- a/src/civitmisc/__main__.py
+++ b/src/civitmisc/__main__.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+import traceback
+
+from helpers.core.utils import disable_style, UnexpectedException, NotImplementedException, InputException, set_verbose, run_verbose, print_verbose, print_exc, sprint
+from helpers.cache import CacheHelper
+from civitmisc.args.argparser import get_args
+
+# TODO: Make verbose and no_style similar to each other
+
+
+def main():
+    try:
+        args = get_args()
+        if args['verbose']:
+            set_verbose(True)
+        else:
+            set_verbose(False)
+
+        if args['with_color'] == False:
+            disable_style()
+
+        subcommand = args['subcommand']
+        print_verbose(args)
+
+        if subcommand == 'cache':
+            if args['scan_model']:
+                CacheHelper.scan_models(args['scan_model'])
+            else:
+                raise InputException('Cache option not provided.')
+        else:
+            raise UnexpectedException(
+                'Unknown subcommand not caught by argparse')
+
+    except Exception as e:
+        sprint('---------')
+        run_verbose(traceback.print_exc)
+        print_exc(e)
+        sprint('---------')

--- a/src/civitmisc/args/argparser.py
+++ b/src/civitmisc/args/argparser.py
@@ -1,0 +1,47 @@
+import os
+import re
+from typing import Dict, List, Union
+
+import argparse
+
+from helpers.core.utils import get_version
+from helpers.argparse import PwdAction, ConfirmAction, ColoredArgParser, BooleanOptionalAction
+
+__all__ = ['get_args']
+
+
+def add_shared_option(par):
+    par.add_argument(
+        '--with-color', action=BooleanOptionalAction, help='Enable styles like colors, background colors and bold/italized texts.'
+    )
+    par.add_argument(
+        '--verbose', action=BooleanOptionalAction, help='Prints out traceback and other useful information.')
+    par.add_argument(
+        '-v', '--version', action='version', version=f'civitdl v{get_version()}', help='Prints out the version of the program.'
+    )
+
+
+parser = ColoredArgParser(
+    prog='civitmisc',
+    description="civitmisc is a cli program for tasks not related to configuration (civitconfig) or downloading model from the API (civitdl)",
+    formatter_class=argparse.RawTextHelpFormatter
+)
+
+
+subparsers = parser.add_subparsers(
+    dest='subcommand',
+    required=True,
+    help='Choose one of the following subcommands: cache.')
+
+cache_parser = subparsers.add_parser(
+    'cache', help='Cache-related tasks. Currently cache stores file path to models and hashes. The purpose of cache is to ensure the same model is not repeatly downloaded if it already exists locally.')
+
+cache_parser.add_argument('-s', '--scan-model', metavar='DIRPATH', type=str,
+                          help='Scans a directory recursively to add path to model files with matching filename to cache.')
+add_shared_option(cache_parser)
+
+
+def get_args():
+    parser_result = parser.parse_args()
+
+    return vars(parser_result)

--- a/src/helpers/cache.py
+++ b/src/helpers/cache.py
@@ -2,16 +2,18 @@
 import os
 import math
 import csv
+import re
 from typing import Dict, Union
 
-from helpers.core.utils import Styler, print_verbose, sprint
+from helpers.core.utils import Styler, print_newlines, print_verbose, sprint
 from helpers.core.constants import app_dirs
+from helpers.core.iohelper import IOHelper
 
 # TODO: Watch out for edge cases where one of the hash is empty.
 # { '123456': { 'model_filepath': 'path', 'SHA256': 'hash1', 'BLAKE3': 'hash2' } }
 
 
-class CacheManager:
+class Cache:
     __CACHE_COLUMNS = ['volume_id', 'model_filepath', 'SHA256', 'BLAKE3']
     __version_id: str
     __filepath: str
@@ -63,7 +65,7 @@ class CacheManager:
                     value.get('BLAKE3', '')
                 ])
 
-    def __get_hash_dict(self) -> Dict:
+    def __get_hash_dict(self) -> Union[None, Dict]:
         return self.__hashes_dict.get(self.__version_id)
 
     def set_local_model_cache(self, model_filepath: str, hashes: Dict[str, str]) -> None:
@@ -82,5 +84,64 @@ class CacheManager:
                 f'Cache of model with version id {self.__version_id} not found.', color='info'))
             return None
         else:
-            filepath = hash_dict['model_filepath']
+            filepath = hash_dict.get('model_filepath')
             return None if not os.path.isfile(filepath) else filepath
+
+    def get_hash_dict(self) -> Union[None, Dict]:
+        return self.__get_hash_dict()
+
+    def get_SHA256_hash(self) -> Union[None, str]:
+        hash_dict = self.__get_hash_dict()
+        if hash_dict:
+            hash = hash_dict.get('SHA256', None)
+            if hash != '':
+                return hash
+
+
+class CacheHelper:
+    @classmethod
+    def scan_models(cls, dir_path: str):
+        data = {}
+        regex = re.compile(
+            r'mid_\d+-vid_(?P<vid>\d+)(?![\w.-]*(csv|txt|png|jpeg|jpg|json))')
+
+        for root, _, filenames in os.walk(dir_path, followlinks=True):
+            for filename in filenames:
+                filepath = os.path.join(root, filename)
+                reg_res = regex.search(filepath)
+                if reg_res:
+                    vid = str(reg_res.group('vid'))
+                    if vid in data:
+                        continue  # already added vid to cache
+                    cache = Cache(version_id=vid)
+                    hash = cache.get_SHA256_hash()
+                    hash_dict = None
+
+                    if hash is None:
+                        csv_filename = os.path.splitext[0] + '.csv'
+                        csv_filepath = os.path.join(
+                            os.path.dirname(filepath), csv_filename)
+
+                        if os.path.exists(csv_filepath):
+                            hash_dict = IOHelper.read_dict_from_csv(
+                                csv_filepath)
+                            hash = hash_dict.get('SHA256', None)
+
+                    if hash is None:
+                        print_newlines(Styler.stylize(
+                            f"""SHA256 hash for the file path below was not found. Proceeding to skip file to protect against corruption.
+                                - File Path: {filepath}
+                            """, color='warning'))
+                    elif IOHelper.compare_hash(filepath, hash):
+                        if hash_dict is None:
+                            hash_dict = cache.get_hash_dict()
+                        cache.set_local_model_cache(
+                            filepath, hash_dict if hash_dict else {})
+                        print_verbose(Styler.stylize(
+                            f'File path added to cache: {filepath}', color='info'))
+                        data[vid] = filepath
+                    else:
+                        print_newlines(Styler.stylize(
+                            f"""SHA256 hash for the file path below is incorrect. Proceeding to skip file to protect against corruption.
+                                - File Path: {filepath}
+                            """, color='warning'))

--- a/src/helpers/core/iohelper.py
+++ b/src/helpers/core/iohelper.py
@@ -4,7 +4,7 @@ import sys
 import time
 import csv
 import hashlib
-from typing import IO, Callable, Iterable, Union
+from typing import IO, Callable, Iterable, List, Union
 
 from ._ui.styler import Styler, InputException, UnexpectedException
 from .utils import get_progress_bar, print_verbose, sprint
@@ -64,6 +64,10 @@ class IOHelper:
 
         return csv_dict
 
+    # @staticmethod
+    # def read_multiple_columns_from_csv(filepath: str):
+    #     return {}
+
     @staticmethod
     def compare_hash(filepath: str, hash: str):
         hasher = hashlib.sha256()
@@ -81,6 +85,7 @@ class IOHelper:
         return digest == hash
 
     # Level 1 #
+
     @classmethod
     def write_to_file(cls, filepath: str, content_chunks: Iterable, mode: str = None, limit_rate: Union[int, None] = 0, encoding: Union[str, None] = None, overwrite: bool = True, use_pb: bool = False, total: float = 0, desc: str = None):
         """Uses content_chunks to write to filepath bit by bit. If use_pb is enabled, it is recommended to set total kwarg to the length of the file to be written."""


### PR DESCRIPTION
**Summary**
- Added civitmisc
- Added CacheHelper class to manage scanning of directories to find model file paths that have been downloaded before. Note that SHA256 is used in CacheHelper to verify the integrity of the model file found.
- Added documentation for civitmisc and cache


**Related Issues?**
#63 

**Comments**
