### PR TITLE
v2.1.1 --- bumped for emergency fix to alias bug with forward slash c…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "civitdl"
-version = "2.1.0"
+version = "2.1.1"
 authors = [ 
    { name = "Owen Truong" } 
 ]


### PR DESCRIPTION
**Summary**
- Fixed bug with program not respecting forward slash when substituting alias on Windows. (Note this was already pushed to development, but this was not supposed to happen. What I was supposed to do was make the changes in a different changes and then push to development).

**Related Issue?**
#96
- Not exactly this issue, but similar. 